### PR TITLE
Add SecLens benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ npx skills add https://github.com/gmh5225/awesome-ai-security --skill ai-powered
 - https://atlas.mitre.org/ [MITRE ATLAS - AI Threat Matrix]
 - https://www.nist.gov/itl/ai-risk-management-framework [NIST AI Risk Management Framework]
 - https://github.com/vectara/hallucination-leaderboard [Model Hallucination Leaderboard]
+- https://github.com/mattersec-labs/seclens [SecLens - benchmark for evaluating LLMs on security vulnerability detection; 5 stakeholder lenses, 406 tasks from real CVEs, 12 models; arXiv:2604.01637]
 - https://github.com/regenrek/aidex [Aidex - practical ranking of models by cost, quality, and use-case fitness]
 
 


### PR DESCRIPTION
Adds [SecLens](https://github.com/mattersec-labs/seclens) to the Benchmarks & Standards section.

SecLens is a benchmark for evaluating LLMs on security vulnerability detection using real CVEs. It covers 5 stakeholder lenses, 406 tasks, and 12 models.

- Paper: https://arxiv.org/abs/2604.01637
- License: MIT