### PR TITLE
Add Armorer Guard MCP security tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ npx skills add https://github.com/gmh5225/awesome-ai-security --skill ai-powered
 - https://github.com/Yanlewen/TradeTrap [TradeTrap - test LLM-based trading agents: prompt injection, MCP hijacking, state tampering, memory poisoning; AI-Trader/Valuecell]
 
 ### AI Security MCP Tools
+- https://github.com/ArmorerLabs/Armorer-Guard [Armorer Guard - local Rust scanner and MCP proxy for prompt injection, credential leakage, exfiltration, and risky tool-call detection before execution]
 - https://github.com/0x4m4/hexstrike-ai [HexStrike AI - 150+ Cybersecurity Tools MCP]
 - https://github.com/cyproxio/mcp-for-security [Pentesting MCP]
 - https://github.com/johnhalloran321/mcpSafetyScanner [MCP Safety Scanner]


### PR DESCRIPTION
Adds Armorer Guard to the AI Security MCP Tools section. I maintain Armorer Guard at Armorer Labs; it is an MIT-licensed local Rust scanner and MCP proxy for prompt injection, credential leakage, exfiltration, and risky tool-call detection before execution.