### PR TITLE
Add mcpaudit to AI Security MCP Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ npx skills add https://github.com/gmh5225/awesome-ai-security --skill ai-powered
 - https://github.com/Yanlewen/TradeTrap [TradeTrap - test LLM-based trading agents: prompt injection, MCP hijacking, state tampering, memory poisoning; AI-Trader/Valuecell]
 
 ### AI Security MCP Tools
+- https://github.com/AndrewXuTurtle/mcpaudit [mcpaudit — MCP server + CLI that audits the MCP servers you already have installed across Claude Desktop, Claude Code, Cursor, Windsurf and VS Code. Tool poisoning (incl. zero-width/bidi chars in tool descriptions), credential blast radius, privilege scope, transport, and supply-chain provenance: homoglyph publisher scopes, registry-removed packages, install hooks, and OSV/GHSA advisories matched to the resolved version. Zero dependencies; nothing installed or executed; MIT]
 - https://github.com/ArmorerLabs/Armorer-Guard [Armorer Guard - local Rust scanner and MCP proxy for prompt injection, credential leakage, exfiltration, and risky tool-call detection before execution]
 - https://github.com/0x4m4/hexstrike-ai [HexStrike AI - 150+ Cybersecurity Tools MCP]
 - https://github.com/cyproxio/mcp-for-security [Pentesting MCP]


### PR DESCRIPTION
Adds [mcpaudit](https://github.com/AndrewXuTurtle/mcpaudit) to *AI Security MCP Tools*. Disclosure: I am the author, and this PR was prepared by an automated agent on the repo owner's behalf.

It fits this section specifically because it runs **as an MCP server** (`--mcp`), exposing `audit_mcp_configs`, `check_package` and `check_advisories` — so an agent can audit its own configuration mid-session. It is also a CLI.

**What it does that the neighbouring entries do not:** it audits servers you have **already installed** rather than scanning one before adoption, and it weights **provenance** alongside content. While building it I found a live impersonation package on npm — `@modelcontextprotoco1/server-filesystem`, digit one instead of lowercase L — that is **byte-identical** to Anthropic's official 2026.1.14 release, republished under a lookalike scope with forged `author: "Anthropic, PBC"` metadata. Content and YARA analysis return clean on it, because the content *is* the official code. Only provenance catches it. ([writeup](https://github.com/AndrewXuTurtle/mcpaudit/blob/main/ADVISORY.md); it was an independent rediscovery, not a first report, and I say so there.)

**Notes:** zero runtime dependencies — including a hand-written tar reader, since taking a dependency tree to report on dependency trees seemed like the wrong trade. Nothing is installed or executed. Free, no API key, MIT. I publish the tool's own [false positives and fixes](https://github.com/AndrewXuTurtle/mcpaudit/blob/main/RESEARCH.md), five classes so far.

Entry follows the section's existing one-line format.