### PR TITLE
Add Humanbound to AI Red Teaming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ npx skills add https://github.com/gmh5225/awesome-ai-security --skill ai-powered
 - https://github.com/NoDataFound/hackGPT [LLM Toolkit for Offensive Security]
 - https://github.com/ipa-lab/hackingBuddyGPT [Autonomous Red-Teaming Agent]
 - https://github.com/Yanlewen/TradeTrap [TradeTrap - test LLM-based trading agents: prompt injection, MCP hijacking, state tampering, memory poisoning; AI-Trader/Valuecell]
+- https://github.com/humanbound/humanbound [Humanbound - open-source CLI that runs LLM-generated adversarial attacks against an agent's HTTP endpoint, scored against OWASP LLM Top 10, OWASP Agentic Top 10, NIST, and EU AI Act mappings]
 
 ### AI Security MCP Tools
 - https://github.com/AndrewXuTurtle/mcpaudit [mcpaudit — MCP server + CLI that audits the MCP servers you already have installed across Claude Desktop, Claude Code, Cursor, Windsurf and VS Code. Tool poisoning (incl. zero-width/bidi chars in tool descriptions), credential blast radius, privilege scope, transport, and supply-chain provenance: homoglyph publisher scopes, registry-removed packages, install hooks, and OSV/GHSA advisories matched to the resolved version. Zero dependencies; nothing installed or executed; MIT]


### PR DESCRIPTION
Adds Humanbound, an open-source (Apache-2.0) CLI that runs LLM-generated adversarial attacks against an AI agent's HTTP endpoint and scores results against OWASP LLM Top 10, OWASP Agentic Top 10, NIST, and EU AI Act mappings.

Repo: https://github.com/humanbound/humanbound