### PR TITLE
Add http-detection-agent to AI Security MCP Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ npx skills add https://github.com/gmh5225/awesome-ai-security --skill ai-powered
 - https://github.com/Sicks3c/hackerone-mcp-server [HackerOne MCP — unofficial Hacker API over stdio: reports, programs, scope, earnings, hacktivity; submit/comment/close; MIT]
 - https://github.com/zhizhuodemao/android_proxy_mcp [Android Proxy MCP - MCP-based Android traffic capture, let AI analyze HTTP/HTTPS via natural language]
 - https://github.com/MHaggis/Security-Detections-MCP [Security Detections MCP - unified Sigma/Splunk ESCU/Elastic/KQL, 71+ tools, 11 prompts, autonomous detection platform]
+- https://github.com/ai-blueteam/http-detection-agent [http-detection-agent - capability-aware HTTP attack detection: Rust CLI and local MCP server over a normalized rule catalog of 76 detections across 62 behavior families; MIT]
 - https://github.com/Correctover/correctover-scan [correctover-scan - zero-config npm CLI that scans MCP client configs (Claude Desktop, Cursor, VS Code) for credential exposure, SSRF, missing auth/transport encryption and other misconfigurations; findings mapped to OWASP AISVS; JSON/SARIF output for CI; MIT]
 - https://github.com/rolandpg/zettelforge [ZettelForge — CTI agentic memory MCP server with entity extraction (CVEs, threat actors, IOCs, MITRE ATT&CK), knowledge graph with alias resolution, STIX 2.1, intent-classified retrieval, OCSF audit logging; offline; MIT]
 


### PR DESCRIPTION
Adds one entry to the existing **AI Security MCP Tools** section.

**Project:** [ai-blueteam/http-detection-agent](https://github.com/ai-blueteam/http-detection-agent)
- Capability-aware HTTP attack detection: a bounded Rust engine running a normalized, deduplicated rule catalog (76 detections across 62 behavior families).
- Ships as the `http-detect` CLI and as a local MCP server for coding agents.
- MIT licensed.

**Disclosure:** I am a maintainer/collaborator of the proposed project. Description is taken from the project README; no adoption, popularity, or endorsement is claimed.

Smallest possible change: one line in an existing section, format matched to neighboring entries. Duplicate check done: no existing listing, issue, or open PR for this project in this repository.